### PR TITLE
feat: a allow a format other than mp3 to the 'toFile' method and enable TS declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,4 @@ dist
 
 *.mp3
 bin/
+*.wav

--- a/src/services/EdgeTTS.ts
+++ b/src/services/EdgeTTS.ts
@@ -170,9 +170,10 @@ export class EdgeTTS {
     }
 
 
-    async toFile(outputPath: string): Promise<string> {
+    async toFile(outputPath: string,format = this.audio_format): Promise<string> {
+        if (!format || typeof format !== 'string') format = this.audio_format;
         const audioBuffer = this.toBuffer();
-        const finalPath = `${outputPath}.${this.audio_format}`;
+        const finalPath = `${outputPath}.${format}`;
         await writeFile(finalPath, new Uint8Array(audioBuffer));
 
         return finalPath;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
 
     "outDir": "dist",
     "noEmit": false,    
-
+    "declaration": true,
     "jsx": "react-jsx",
 
     "strict": true,


### PR DESCRIPTION
- Add *.wav to gitignore to exclude WAV audio files
- Enable TypeScript declaration generation in tsconfig
- Allow custom audio format in EdgeTTS toFile method

*Hey, the npm build doesn't have the types*
- a small change to allow a format other than mp3 to the 'toFile' method.